### PR TITLE
add code and article link for keycloak-connect-graphql

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 * [How to exchange token from an external provider to a keycloak token](https://www.mathieupassenaud.fr/token-exchange-keycloak/)
 * [Building an Event Listener SPI (Plugin) for Keycloak](https://dev.to/adwaitthattey/building-an-event-listener-spi-plugin-for-keycloak-2044)
 * [Keycloak user migration – connect your legacy authentication system to Keycloak](https://codesoapbox.dev/keycloak-user-migration/)
+* [Keycloak Authentication and Authorization in GraphQL](https://medium.com/@darahayes/keycloak-authentication-and-authorization-in-graphql-ad0a1685f7da)
 
 ## Talks
 *  [JDD2015 - Keycloak Open Source Identity and Access Management Solution](https://www.youtube.com/watch?v=TuEkj25lbd0)
@@ -153,6 +154,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 *  [Keycloak Open-Shift integration](https://github.com/keycloak/openshift-integration)
 *  [Keycloak, Kong and Konga setup scripts (local development)](https://github.com/JaouherK/Kong-konga-Keycloak/blob/master/start.sh)
 *  [SSO for Keycloak and Nextcloud with SAML](https://stackoverflow.com/questions/48400812/sso-with-saml-keycloak-and-nextcloud)
+* [Keycloak Connect GraphQL Adapter for Node.js](https://github.com/aerogear/keycloak-connect-graphql)
 
 ## Quick demo Videos
 * [Keycloak with istio envoy jwt-auth proxy](https://www.youtube.com/watch?v=wscX7JMfuBI)


### PR DESCRIPTION
Hi there, I'm the author of [keycloak-connect-graphql](https://github.com/aerogear/keycloak-connect-graphql). I think it would be nice to get it added to this great list as it is the first Keycloak integration I know of for Node.js based GraphQL servers. It is designed to work with the official keycloak-connect adapter for Node.js. I've included a link to the source code and a link to an article I published about the library.

The project is actively maintained and used as part of our other open source projects. Thank you!