### PR TITLE
Add link to keycloak-testcontainer for node.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 *  [Keycloak Authenticator for Duo's Universal Prompt](https://github.com/instipod/DuoUniversalKeycloakAuthenticator)
 *  [Keycloak extension for creating multi-tenant IAM for B2B SaaS applications](https://github.com/anarsultanov/keycloak-multi-tenancy)
 *  [OpenID Connect for Identity Assurance (OIDC4IDA) on Keycloak](https://github.com/Bredstone/Keycloak-Extension-OIDC4IDA)
+*  [Keycloak Testcontainer for Node.js](https://github.com/slemke/keycloak-testcontainer)
 
 ## Integrations
 *  [Keycloak HTTP/MQTT/CoAP IoT Brokers Adapter](https://github.com/authbroker/authbroker)


### PR DESCRIPTION
Hey @thomasdarimont,

I have written a test container implementation for Keycloak in Typescript so it can be used in Node.js (or something similar). The idea was to have a fully configureable test container which I found wasn't really around or lacked documentation.

Currently, the following features are supported:

* Run in dev mode with healthcheck implementation
* ES6 and common.js imports
* Enabling and disabling features with builder commands (metrics, health, impersonation, ...)
* Access to admin client and custom admin user
* Realm import
* Database Configuration

Maybe this is a useful addition to the awesomelist, maybe not - but I found it rather useful in some of my projects :)

**Note**: I wasn't sure where to put this, so I added it under `Community Extensions`. If you think there is a better spot, let me know and I'll update it accordingly.