### PR TITLE
add keycloak-altcha

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 *  [evosec/keycloak-ipaddress-authenticator](https://github.com/evosec/keycloak-ipaddress-authenticator)
 *  [Identity provider for German eID L21s/keycloak-eid-identity-provider](https://github.com/L21s/keycloak-eid-identity-provider/tree/main)
 *  [Identity provider for German eID governikus/keycloak-eid-identity-provider](https://gitlab.opencode.de/governikus/keycloak-eid-identity-provider)
+*  [ALTCHA Captcha Extension for Keycloak](https://git.lacontrevoie.fr/lacontrevoie/keycloak-altcha)
 
 ## Integrations
 *  [Keycloak HTTP/MQTT/CoAP IoT Brokers Adapter](https://github.com/authbroker/authbroker)


### PR DESCRIPTION
Hi,

I am writing on behalf of the French nonprofit organization [La Contre-Voie](https://lacontrevoie.fr/en/) ; I am responsible of maintaining our extension keycloak-altcha which purpose is to insert a proof-of-work captcha based on [ALTCHA](https://altcha.org/).

We got our extension referenced in [ALTCHA’s documentation](https://altcha.org/docs/v2/libraries/) and we would like to bring it to the attention of Keycloak folks.

FYI we also have a [repository mirror on GitHub](https://github.com/lacontrevoie/keycloak-altcha), though the static JAR archives and all the development are hosted on our own forge (and registrations are open).

Of course, we wholeheartedly welcome any contribution to our code.

Best,

Neil