### PR TITLE
Add link to https://github.com/hu553in/invites-keycloak

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,7 @@ Contributions welcome. Add links through pull requests or create an issue to sta
 *  [tidecloak (Keycloak fork)](https://tide.org/tidecloak)
 *  [Keycloak reCAPTCHA Password Defense](https://github.com/califio/keycloak-recaptcha-password-defense)
 *  [Keycloak Custom Attribute IDP Linking](https://github.com/sd-f/keycloak-custom-attribute-idp-linking)
+*  [Invites for your Keycloak](https://github.com/hu553in/invites-keycloak)
 
 ## Integrations
 *  [Keycloak HTTP/MQTT/CoAP IoT Brokers Adapter](https://github.com/authbroker/authbroker)


### PR DESCRIPTION
Hello.
This is my pet-project, which is also starting to being used in one of my small non-profit productions.
Core thing: a standalone self-hosted Spring Boot app which allows to manage invites to Keycloak instance.
Would be glad if it will appear here.
Thanks.